### PR TITLE
Corrigindo falha de renderização no Jupyter Web

### DIFF
--- a/01.ipynb
+++ b/01.ipynb
@@ -733,7 +733,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|----|---|\n",
     "| *Exemplo 1* | João 100 5.50  | João 550.00 | \n",
     "| *Exemplo 2* | Maria 200 20.50 | Maria 4100.00 |\n",
@@ -760,7 +760,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|----|---|\n",
     "| *Exemplo 1* | João 500 1230.30  | João 684.54 | \n",
     "| *Exemplo 2* | Pedro 700 0.00 | Pedro 700.00 |\n",
@@ -787,7 +787,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|----|---|\n",
     "| *Exemplo 1* | 12 1 5.30 <br> 16 2 5.10 | VALOR A PAGAR: 15.50 |\n",
     "| *Exemplo 2* | 13 2 15.30 <br> 161 4 5.20 | VALOR A PAGAR: 51.40 |\n",
@@ -816,7 +816,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|----|---|\n",
     "| *Exemplo 1* | 576 | 5 nota(s) de 100,00 <br /> 1 nota(s) de 50,00 <br /> 1 nota(s) de 20,00 <br /> 0 nota(s) de 10,00 <br /> 1 nota(s) de 5,00  <br /> 0 nota(s) de 2,00  <br /> 1 nota(s) de 1,00 |\n",
     "| *Exemplo 2* | 11257 | 112 nota(s) de 100,00 <br /> 1 nota(s) de 50,00 <br /> 0 nota(s) de 20,00 <br /> 0 nota(s) de 10,00 <br /> 1 nota(s) de 5,00 <br /> 1 nota(s) de 2,00 <br /> 0 nota(s) de 1,00 |\n",
@@ -847,7 +847,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|----|---|\n",
     "| *Exemplo 1* | 576.73 | NOTAS: <br /> 5 nota(s) de 100,00 <br /> 1 nota(s) de 50,00 <br /> 1 nota(s) de 20,00 <br /> 0 nota(s) de 10,00 <br /> 1 nota(s) de 5,00  <br /> 0 nota(s) de 2,00  <br /> MOEDAS: <br /> 1 moeda(s) de 1,00 <br /> 1 moeda(s) de 0,50 <br /> 0 moeda(s) de 0,25 <br /> 2 moeda(s) de 0,10 <br /> 0 moeda(s) de 0,05 <br /> 3 moeda(s) de 0,01 |\n",
     "| *Exemplo 2* | 4.00 | NOTAS: <br /> 0 nota(s) de 100,00 <br /> 0 nota(s) de 50,00 <br /> 0 nota(s) de 20,00 <br /> 0 nota(s) de 10,00 <br /> 0 nota(s) de 5,00  <br /> 2 nota(s) de 2,00 <br /> MOEDAS: <br /> 0 moeda(s) de 1,00 <br /> 0 moeda(s) de 0,50 <br /> 0 moeda(s) de 0,25 <br /> 0 moeda(s) de 0,10 <br /> 0 moeda(s) de 0,05 <br /> 0 moeda(s) de 0,01 |\n",
@@ -905,7 +905,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|----|---|\n",
     "| *Exemplo 1* | 556  | 00:09:16 | \n",
     "| *Exemplo 2* | 1 | 00:00:01 |\n",
@@ -929,7 +929,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/02.ipynb
+++ b/02.ipynb
@@ -687,7 +687,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|:----:|---|\n",
     "| *Exemplo 1* | 5 | [0,25) | \n",
     "| *Exemplo 2* | 50 | [50,75) |\n",
@@ -718,7 +718,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|----|---|\n",
     "| *Exemplo 1* | vertebrado<br/>mamifero<br/>onivoro | homem | \n",
     "| *Exemplo 2* | vertebrado<br/>ave<br/>carnivoro | aguia |\n",
@@ -768,7 +768,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|:-:|:-:|\n",
     "| *Exemplo 1* | 4.5<br/>-2.2 | Q4 | \n",
     "| *Exemplo 2* | 0.1<br/>0.0 | Eixo X |\n",
@@ -802,7 +802,7 @@
    "metadata": {},
    "source": [
     "| Salário de contribuição | Alíquota |\n",
-    "|-|:-:|:-:|\n",
+    "|:-:|:-:|\n",
     "| Até 1.693,72 | 8% | \n",
     "| De 1.693,73 a 2.822,90 | 9% |\n",
     "| De 2.822,91 até 5.645,80 | 11% |"
@@ -823,7 +823,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|:-:|-|\n",
     "| *Exemplo 1* | 7456.57 | 621.04 6835.53 | \n",
     "| *Exemplo 2* | 2822.90 | 254.06 2568.84 |\n",
@@ -860,7 +860,7 @@
    "metadata": {},
    "source": [
     "| Base de cálculo (R\\$) | Alíquota | Parcela a deduzir |\n",
-    "|-|:-:|:-:|:-:|\n",
+    "|:-:|:-:|:-:|\n",
     "| Até 1.903,98 | - | - |\n",
     "| De 1.903,99 até 2.826,65 | 7,5% | 142,80 |\n",
     "| De 2.826,66 até 3.751,05 | 15% | 354,80 |\n",
@@ -883,7 +883,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|:-:|-|\n",
     "| *Exemplo 1* | 6835.53 | 1010.41 5825.12 | \n",
     "| *Exemplo 2* | 2568.84 | 49.86 2518.98 |\n",
@@ -916,7 +916,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/03.ipynb
+++ b/03.ipynb
@@ -319,7 +319,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [],
@@ -420,7 +419,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|:----:|---|\n",
     "| *Exemplo 1* | 5<br/>100<br/>40<br/>32<br/>87<br/>90 | \\[0,20\\) - 1 <br/> \\[20,40\\) - 1 <br/> \\[40,60\\) - 1 <br/> \\[60,80\\) - 0 <br/> \\[80,100\\) - 3  <br/> Máximo: 100 (0) <br/> Mínimo: 32 (2) | \n",
     "| *Exemplo 2* | 3<br/>12<br/>29<br/>45 | \\[0,20\\) - 1 <br/> \\[20,40\\) - 1 <br/> \\[40,60\\) - 1 <br/> \\[60,80\\) - 0 <br/> \\[80,100\\) - 0  <br/> Máximo: 45 (2) <br/> Mínimo: 12 (0) | \n",
@@ -450,7 +449,7 @@
     "collapsed": true
    },
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|:-:|:-|\n",
     "| *Exemplo 1* | 10 | 1 2 3 5 6 7 10 | \n",
     "| *Exemplo 2* | 15 | 1 2 3 5 6 7 10 11 13 |\n",
@@ -491,7 +490,7 @@
     "collapsed": true
    },
    "source": [
-    "| | Velocidades | Saída |\n",
+    "|.| Velocidades | Saída |\n",
     "|-|:-:|:-|\n",
     "| *Exemplo 1* | 15.38<br/>55.49<br/>48.65  | 15.38 55.49 48.65 <br/> 30.76 110.98 97.30 <br/> 46.14 166.47 145.95 <br/> 61.52 221.96 194.60 <br/> 76.90 277.45 243.25 <br/> 92.28 332.94 291.90 <br/> 107.66 388.43 340.55 <br/> 123.04 443.92 389.20 <br/> 138.42 499.41 437.85 <br/> P2 | \n",
     "| *Exemplo 2* | 42.27<br/>95.26<br/>72.25 | 42.27 95.26 72.25 <br/> 84.54 190.52 144.50 <br/> 126.81 285.78 216.75 <br/> 169.08 381.04 289.00 <br/> 211.35 476.30 361.25 <br/> 253.62 571.56 433.50 <br/> P2 |\n",
@@ -531,7 +530,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|:-:|:-|\n",
     "| *Exemplo 1* | 3  | Jogador 2 <br/> Empate <br/> Jogador 2 <br/> Placar final: 0 x 2 <br/> Partida vencida pelo Jogador 2! | \n",
     "| *Exemplo 2* | 5 | Jogador 1 <br/> Jogador 1 <br/> Empate <br/> Empate <br/> Jogador 1 <br/> Placar final: 3 x 0 <br/> Partida vencida pelo Jogador 1! |\n",
@@ -606,7 +605,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/04.ipynb
+++ b/04.ipynb
@@ -41,9 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def bom_dia():\n",
@@ -118,7 +116,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [],
@@ -188,7 +185,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [],
@@ -246,7 +242,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "scrolled": true
    },
    "outputs": [],
@@ -340,9 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   },
@@ -382,7 +375,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|:----:|:-:|\n",
     "| *Exemplo 1* | 3<br/>min<br/>35<br/>70<br/>35<br/>mean<br/>10<br/>74<br/>181<br/>eye<br/>23<br/>78<br/>197 | 35<br/>88<br/>74 | \n",
     "| *Exemplo 2* | 4<br/>min<br/>41<br/>27<br/>32<br/>min<br/>10<br/>21<br/>6<br/>max<br/>15<br/>41<br/>72<br/>max<br/>40<br/>21<br/>63 | 27<br/>6<br/>72<br/>41 | \n",
@@ -411,7 +404,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|----|:-:|\n",
     "| *Exemplo 1* | 280<br/>Agora dá: Daenerys Targaryen, Filha da Tormenta, Não Queimada, Mãe de Dragões, Rainha de Mereen,<br/>Rainha dos Ândalos e dos Primeiros Homens, Quebradora de Correntes, Senhora dos Sete Reinos,<br/>Khaleesi dos Dothraki, a Primeira de Seu Nome. Descendente da Casa Targaryen. | OK | \n",
     "| *Exemplo 2* | 140<br/>Jon Snow. Ele é Rei do Norte. | OK | \n",
@@ -442,7 +435,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "| | Entrada | Saída |\n",
+    "|.| Entrada | Saída |\n",
     "|-|:-:|-|\n",
     "| *Exemplo 1* | 1200.00 | 1104.00 | \n",
     "| *Exemplo 2* | 5485.00 | 4474.05 |\n",
@@ -475,7 +468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
A falha ocorria devido a posição 0,0 da tabela (canto esquerdo superior) estar vazio, o que quebrava a tabela no Jupyter Web. Foi adicionado um `.` para preencher esse espaço e corrigir as tabelas.